### PR TITLE
docs: remove one-time donations from funding info

### DIFF
--- a/.github/FUNDING.md
+++ b/.github/FUNDING.md
@@ -6,10 +6,6 @@ If you find this project useful and would like to support its development, you c
 You can sponsor me directly through GitHub Sponsors:
 - [Sponsor @d0ugal on GitHub](https://github.com/sponsors/d0ugal)
 
-## One-time Donations
-- **Ko-fi**: [Buy me a coffee](https://ko-fi.com/d0ugal)
-- **PayPal**: [PayPal.me/d0ugal](https://paypal.me/d0ugal)
-
 ## Other Ways to Support
 - ⭐ **Star the repository** - Show your appreciation
 - 🐛 **Report bugs** - Help improve the project


### PR DESCRIPTION
Remove Ko-fi and PayPal donation links from funding information.

This simplifies the funding options to focus on GitHub Sponsors and other non-monetary ways to support the project.