### PR TITLE
fix: make yaml optional and always overlay env vars on config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,7 +47,6 @@ func main() {
 	}
 
 	cfg, err := config.LoadConfig(configPath)
-
 	if err != nil {
 		slog.Error("Failed to load configuration", "error", err, "path", configPath) //nolint:gosec // G706: configPath is from CLI/env, not HTTP input; slog structures the value safely
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
@@ -32,29 +33,20 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Check if we should use environment variables
-	configFromEnv := os.Getenv("FILESYSTEM_EXPORTER_CONFIG_FROM_ENV") == "true"
-
-	// Load configuration
-	var (
-		cfg *config.Config
-		err error
-	)
-
-	if configFromEnv {
-		cfg, err = config.LoadConfig("", true)
-	} else {
-		// Use environment variable if config flag is not provided
-		if configPath == "" {
-			if envConfig := os.Getenv("CONFIG_PATH"); envConfig != "" {
-				configPath = envConfig
-			} else {
-				configPath = "config.yaml"
-			}
-		}
-
-		cfg, err = config.LoadConfig(configPath, false)
+	if os.Getenv("FILESYSTEM_EXPORTER_CONFIG_FROM_ENV") == "true" {
+		fmt.Fprintln(os.Stderr, "Warning: FILESYSTEM_EXPORTER_CONFIG_FROM_ENV is deprecated and has no effect. Env vars are always applied on top of yaml config.")
 	}
+
+	// Use environment variable if config flag is not provided
+	if configPath == "" {
+		if envConfig := os.Getenv("CONFIG_PATH"); envConfig != "" {
+			configPath = envConfig
+		} else {
+			configPath = "config.yaml"
+		}
+	}
+
+	cfg, err := config.LoadConfig(configPath)
 
 	if err != nil {
 		slog.Error("Failed to load configuration", "error", err, "path", configPath) //nolint:gosec // G706: configPath is from CLI/env, not HTTP input; slog structures the value safely

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ func applyEnvVars(cfg *Config) error {
 	if address := os.Getenv("FILESYSTEM_EXPORTER_SERVER_ADDRESS"); address != "" {
 		if host, portStr, err := net.SplitHostPort(address); err == nil {
 			cfg.Server.Host = host
+
 			if port, err := strconv.Atoi(portStr); err != nil {
 				return fmt.Errorf("invalid server port in address: %w", err)
 			} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,26 +43,29 @@ type DirectoryGroup struct {
 	Timeout            Duration `yaml:"timeout"` // Timeout for du command execution (default: 5m)
 }
 
-// LoadConfig loads configuration from a YAML file
-func LoadConfig(path string, configFromEnv bool) (*Config, error) {
-	if configFromEnv {
-		return loadFromEnv()
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read config file: %w", err)
-	}
-
+// LoadConfig loads configuration from an optional YAML file, then overlays environment variables.
+func LoadConfig(path string) (*Config, error) {
 	var config Config
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
+
+	if path != "" {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if err := yaml.Unmarshal(data, &config); err != nil {
+				return nil, fmt.Errorf("failed to parse config file %s: %w", path, err)
+			}
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to read config file %s: %w", path, err)
+		}
 	}
 
 	// Apply generic environment variables (TRACING_ENABLED, PROFILING_ENABLED, etc.)
-	// These are handled by promexporter and are shared across all exporters
 	if err := promexporter_config.ApplyGenericEnvVars(&config.BaseConfig); err != nil {
 		return nil, fmt.Errorf("failed to apply generic environment variables: %w", err)
+	}
+
+	// Overlay exporter-specific environment variables
+	if err := applyEnvVars(&config); err != nil {
+		return nil, fmt.Errorf("failed to apply environment overrides: %w", err)
 	}
 
 	// Set defaults
@@ -76,85 +79,42 @@ func LoadConfig(path string, configFromEnv bool) (*Config, error) {
 	return &config, nil
 }
 
-// loadFromEnv loads configuration from environment variables
-func loadFromEnv() (*Config, error) {
-	config := &Config{}
-
-	// Load base configuration from environment
-	baseConfig := &promexporter_config.BaseConfig{}
-
-	// Server configuration
+// applyEnvVars overlays FILESYSTEM_EXPORTER_* environment variables onto cfg.
+func applyEnvVars(cfg *Config) error {
 	if address := os.Getenv("FILESYSTEM_EXPORTER_SERVER_ADDRESS"); address != "" {
-		// Parse host:port from address
 		if host, portStr, err := net.SplitHostPort(address); err == nil {
-			baseConfig.Server.Host = host
-
+			cfg.Server.Host = host
 			if port, err := strconv.Atoi(portStr); err != nil {
-				return nil, fmt.Errorf("invalid server port in address: %w", err)
+				return fmt.Errorf("invalid server port in address: %w", err)
 			} else {
-				baseConfig.Server.Port = port
+				cfg.Server.Port = port
 			}
 		} else {
-			return nil, fmt.Errorf("invalid server address format: %w", err)
+			return fmt.Errorf("invalid server address format: %w", err)
 		}
-	} else {
-		baseConfig.Server.Host = "0.0.0.0"
-		baseConfig.Server.Port = 8080
 	}
 
-	// Logging configuration
 	if level := os.Getenv("FILESYSTEM_EXPORTER_LOGGING_LEVEL"); level != "" {
-		baseConfig.Logging.Level = level
-	} else {
-		baseConfig.Logging.Level = "info"
+		cfg.Logging.Level = level
 	}
 
 	if format := os.Getenv("FILESYSTEM_EXPORTER_LOGGING_FORMAT"); format != "" {
-		baseConfig.Logging.Format = format
-	} else {
-		baseConfig.Logging.Format = "json"
+		cfg.Logging.Format = format
 	}
 
-	// Metrics configuration
 	if intervalStr := os.Getenv("FILESYSTEM_EXPORTER_METRICS_COLLECTION_DEFAULT_INTERVAL"); intervalStr != "" {
 		if interval, err := time.ParseDuration(intervalStr); err != nil {
-			return nil, fmt.Errorf("invalid metrics default interval: %w", err)
+			return fmt.Errorf("invalid metrics default interval: %w", err)
 		} else {
-			baseConfig.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: interval}
-			baseConfig.Metrics.Collection.DefaultIntervalSet = true
+			cfg.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: interval}
+			cfg.Metrics.Collection.DefaultIntervalSet = true
 		}
-	} else {
-		baseConfig.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: time.Second * 30}
 	}
 
-	// Tracing configuration
-	if enabledStr := os.Getenv("TRACING_ENABLED"); enabledStr != "" {
-		enabled := enabledStr == "true"
-		baseConfig.Tracing.Enabled = &enabled
-	}
+	// Append directories defined in environment variables
+	cfg.loadDirectoriesFromEnv()
 
-	if serviceName := os.Getenv("TRACING_SERVICE_NAME"); serviceName != "" {
-		baseConfig.Tracing.ServiceName = serviceName
-	}
-
-	if endpoint := os.Getenv("TRACING_ENDPOINT"); endpoint != "" {
-		baseConfig.Tracing.Endpoint = endpoint
-	}
-
-	config.BaseConfig = *baseConfig
-
-	// Load directories from environment variables
-	config.loadDirectoriesFromEnv()
-
-	// Set defaults for any missing values
-	setDefaults(config)
-
-	// Validate configuration
-	if err := config.Validate(); err != nil {
-		return nil, fmt.Errorf("configuration validation failed: %w", err)
-	}
-
-	return config, nil
+	return nil
 }
 
 // loadDirectoriesFromEnv loads directory configuration from environment variables


### PR DESCRIPTION
## Summary

- `LoadConfig(path string)` replaces the old two-argument form — no more binary yaml-only vs env-only choice
- YAML is loaded if the file exists; silently skipped if absent
- `FILESYSTEM_EXPORTER_*` environment variables are always overlaid on top of yaml values
- `FILESYSTEM_EXPORTER_CONFIG_FROM_ENV` is kept but now emits a deprecation warning to stderr (it is a no-op)

## Test plan

- [ ] Run with only a yaml file — confirm yaml values are used
- [ ] Run with only env vars (no yaml) — confirm env vars are used and no error
- [ ] Run with both yaml and env vars — confirm env vars take precedence
- [ ] Set `FILESYSTEM_EXPORTER_CONFIG_FROM_ENV=true` — confirm deprecation warning is printed