### PR TITLE
chore: remove deprecated CONFIG_FROM_ENV env var

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"log/slog"
 	"os"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,10 +32,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	if os.Getenv("FILESYSTEM_EXPORTER_CONFIG_FROM_ENV") == "true" {
-		fmt.Fprintln(os.Stderr, "Warning: FILESYSTEM_EXPORTER_CONFIG_FROM_ENV is deprecated and has no effect. Env vars are always applied on top of yaml config.")
-	}
-
 	// Use environment variable if config flag is not provided
 	if configPath == "" {
 		if envConfig := os.Getenv("CONFIG_PATH"); envConfig != "" {


### PR DESCRIPTION
## Summary
The env var has been documented as deprecated/no-op for several releases. Env vars are always applied on top of yaml config unconditionally, so the deprecation warning is the only thing this code does. Drop the warning block.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`